### PR TITLE
Revert "major: disable deletions entirely"

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,20 @@ async def sync_endpoint(request: Request):
 
 @app.post("/finalize")
 async def finalize_endpoint(request: Request):
-    return {"finalized": True}
+    try:
+        data = await request.json()
+        parent = data["parent"]
+        aws_resource_tags = [
+            {"Key": "kubernetes_resource_name",
+                "Value": parent["metadata"]["name"]},
+            {"Key": "captain_domain",
+                "Value": os.environ.get('CAPTAIN_DOMAIN')}
+        ]
+        print(aws_resource_tags)
+        return await asyncio.to_thread(finalize_hook, aws_resource_tags)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        raise HTTPException(status_code=500, detail=traceback.format_exc())
 
 
 def sync(parent, children):


### PR DESCRIPTION
### **User description**
Reverts GlueOps/metacontroller-operator-waf#46


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Reverted previous changes that disabled deletions entirely.
- Enhanced the `/finalize` endpoint to process request data and AWS resource tags.
- Added error handling with logging and HTTP 500 response in case of exceptions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Revert and enhance `/finalize` endpoint with error handling</code></dd></summary>
<hr>

main.py

<li>Reverted changes to the <code>/finalize</code> endpoint.<br> <li> Added error handling with logging and HTTP 500 response.<br> <li> Introduced processing of request data and AWS resource tags.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/metacontroller-operator-waf/pull/52/files#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1">+14/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

